### PR TITLE
registerClientScript() does not depend from Alias

### DIFF
--- a/YiinfiniteScroller.php
+++ b/YiinfiniteScroller.php
@@ -61,7 +61,7 @@ class YiinfiniteScroller extends CBasePager {
     }
 
     public function registerClientScript() {
-        $url = CHtml::asset(Yii::getPathOfAlias('ext.yiinfinite-scroll.assets').'/jquery.infinitescroll.min.js');
+        $url = CHtml::asset(dirname(__FILE__).'/assets/jquery.infinitescroll.min.js');
         Yii::app()->clientScript->registerScriptFile($url);
     }
 


### PR DESCRIPTION
I had an issue with yiinfinite-scroll using popular Yii setup like:

```
/
    backend/
    common/
        ...
        extensions/
            yiinfinite-scroll
            ...
    console/
        ...
    frontend/
        ...
```

Calling widget inside frontend app will create "The asset to be published does not exist" fatal error.

I've updated registerClientScript() to fix this issue.
